### PR TITLE
fix: Prevent RCE in mkcomp/mkhero via command injection

### DIFF
--- a/mkcomp
+++ b/mkcomp
@@ -41,7 +41,7 @@ system (join(" ",
     "-size 2000x1200 xc:black",
     "-gravity northwest",
     join (' ', map { f($_->{pos}, $_->{sym}, "white", "cyan") } $symbols->@*),
-    $ARGV[0]
+    quotemeta($ARGV[0])
 ));
 
 system (join(" ",
@@ -49,5 +49,5 @@ system (join(" ",
     "-size 2000x1200 xc:white",
     "-gravity northwest",
     join (' ', map { f($_->{pos}, $_->{sym}, "black", "crimson") } $symbols->@*),
-    $ARGV[1]
+    quotemeta($ARGV[1])
 ));

--- a/mkhero
+++ b/mkhero
@@ -30,12 +30,12 @@ system(join(' ',
   "magick",
   "-size 2000x2200 xc:black -gravity north -pointsize 128 -font Myna -strokewidth 2",
   (map { "-fill white -stroke white -annotate +0+$_->{pos} \"$_->{string}\"" } $dark->@*),
-  $ARGV[0]
+  quotemeta($ARGV[0])
 ));
 
 system(join(' ',
   "magick",
   "-size 2000x2200 xc:white -gravity north -pointsize 128 -font Myna -strokewidth 2",
   (map { "-fill black -stroke black -annotate +0+$_->{pos} \"$_->{string}\"" } $light->@*),
-  $ARGV[1]
+  quotemeta($ARGV[1])
 ));


### PR DESCRIPTION
## Summary
Added `quotemeta()` escaping to `$ARGV[0/1]` in Perl scripts.

## Test plan
- PoC blocked
- Normal runs work
- Syntax OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>